### PR TITLE
Optimize ARP cache population

### DIFF
--- a/profile_discovery.py
+++ b/profile_discovery.py
@@ -1,0 +1,21 @@
+import asyncio
+import cProfile
+import pprint
+import time
+
+from pyprof2calltree import convert
+
+from aiodiscover import DiscoverHosts
+
+start_time = int(time.time() * 1000000)
+pr = cProfile.Profile()
+pr.enable()
+
+discover_hosts = DiscoverHosts()
+hosts = asyncio.run(discover_hosts.async_discover())
+pprint.pprint(hosts)
+
+pr.disable()
+pr.create_stats()
+pr.dump_stats(f"aiodiscover.{start_time}.cprof")
+convert(pr.getstats(), f"callgrind.out.{start_time}")


### PR DESCRIPTION
Optimize ARP cache population

- Use a single non-blocking socket to populate the arp cache
- Add a profiler script: profile_discovery.py
- Avoid populating the arp cache if it already exists
- Loosen MAC address validation to handle leading 0s and short format
- Run ip_route.get_neighbours in the executor.
