### PR TITLE
Ensure mac addresses with leading zeros are not striped

### DIFF
--- a/aiodiscover/discovery.py
+++ b/aiodiscover/discovery.py
@@ -3,7 +3,6 @@ import logging
 from contextlib import suppress
 
 from dns import exception, message, rdatatype
-from pyroute2 import IPRoute
 
 from .network import SystemNetworkData
 
@@ -128,6 +127,8 @@ class DiscoverHosts:
         """Init the discovery hosts."""
         self.ip_route = None
         with suppress(Exception):
+            from pyroute2 import IPRoute  # pylint: disable=import-outside-toplevel
+
             self.ip_route = IPRoute()
 
     async def async_discover(self):

--- a/aiodiscover/network.py
+++ b/aiodiscover/network.py
@@ -104,6 +104,7 @@ def _fill_neighbor(neighbours, ip, mac):
         return
     if not VALID_MAC_ADDRESS.match(mac):
         return
+    mac = ":".join([i.zfill(2) for i in mac.split(":")])
     if mac in IGNORE_MACS:
         return
     neighbours[ip] = mac

--- a/aiodiscover/tests/test_discovery.py
+++ b/aiodiscover/tests/test_discovery.py
@@ -48,14 +48,14 @@ async def test_async_discover_hosts_with_dns_mock_neighbor_mock():
         "aiodiscover.network.SystemNetworkData.async_get_neighbors",
         return_value={
             "1.2.3.4": "aa:bb:cc:dd:ee:ff",
-            "4.5.5.6": "ff:bb:cc:dd:ee:ff",
+            "4.5.5.6": "ff:bb:cc:0d:ee:ff",
         },
     ):
         hosts = await discover_hosts.async_discover()
 
     assert hosts == [
         {"hostname": "router", "ip": "1.2.3.4", "macaddress": "aa:bb:cc:dd:ee:ff"},
-        {"hostname": "any", "ip": "4.5.5.6", "macaddress": "ff:bb:cc:dd:ee:ff"},
+        {"hostname": "any", "ip": "4.5.5.6", "macaddress": "ff:bb:cc:0d:ee:ff"},
     ]
 
 


### PR DESCRIPTION
Fixes discovery in home assistant for mac addresses that have a leading 0 in one of the matchers
