### PR TITLE
Fix KeyError when dns server does not respond for a single ip

### DIFF
--- a/aiodiscover/discovery.py
+++ b/aiodiscover/discovery.py
@@ -128,7 +128,7 @@ async def async_query_for_ptr_with_proto(
         except OSError:
             break
 
-    return [protocol.responses.get(query_for_ip[ip]) for ip in ips_to_lookup]
+    return [protocol.responses.get(query_for_ip.get(ip)) for ip in ips_to_lookup]  # type: ignore
 
 
 class DiscoverHosts:
@@ -141,9 +141,9 @@ class DiscoverHosts:
     def _get_sys_network_data(self) -> SystemNetworkData:
         if not self._ip_route:
             with suppress(Exception):
-                from pr2modules.iproute import (
+                from pr2modules.iproute import (  # type: ignore # pylint: disable=import-outside-toplevel
                     IPRoute,
-                )  # type: ignore # pylint: disable=import-outside-toplevel
+                )
 
                 self._ip_route = IPRoute()
         sys_network_data = SystemNetworkData(self._ip_route)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,4 +28,4 @@ ignore =
 	E402
 	W291
 	W503
-max-line-length = 100
+max-line-length = 120


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/70402
```
File "/usr/src/homeassistant/homeassistant/components/dhcp/__init__.py", line 306, in async_discover
for host in await self._discover_hosts.async_discover():
File "/usr/local/lib/python3.9/site-packages/aiodiscover/discovery.py", line 166, in async_discover
hostnames = await self.async_get_hostnames(sys_network_data)
File "/usr/local/lib/python3.9/site-packages/aiodiscover/discovery.py", line 201, in async_get_hostnames
results = await async_query_for_ptrs(nameserver, ips_to_lookup)
File "/usr/local/lib/python3.9/site-packages/aiodiscover/discovery.py", line 101, in async_query_for_ptrs
return await async_query_for_ptr_with_proto(protocol, ips_to_lookup)
File "/usr/local/lib/python3.9/site-packages/aiodiscover/discovery.py", line 131, in async_query_for_ptr_with_proto
return [protocol.responses.get(query_for_ip[ip]) for ip in ips_to_lookup]
File "/usr/local/lib/python3.9/site-packages/aiodiscover/discovery.py", line 131, in <listcomp>
return [protocol.responses.get(query_for_ip[ip]) for ip in ips_to_lookup]
KeyError: IPv4Address(192.168.1.20)
```

