### PR TITLE
fix: update poetry to v2 + add license to metadata

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1794,4 +1794,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "cf39a19109ebfc6698fd26b6c7c0b9528a7580b9a00355cb137fff11a9309c3a"
+content-hash = "dfbbd3f5e99580e00a95c1446520d784ac108c4b08be33f87ff1ae8f9c124b06"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,30 @@
-[tool.poetry]
+[project]
 name = "aiodiscover"
 version = "2.2.0"
+license = "Apache-2.0"
 description = "Discover hosts by arp and ptr lookup"
-authors = ["J. Nick Koston <nick@koston.org>"]
+authors = [{ name = "J. Nick Koston", email = "nick@koston.org" }]
 readme = "README.md"
-repository = "https://github.com/uilibs/aiodiscover"
-documentation = "https://aiodiscover.readthedocs.io"
+requires-python = ">=3.9"
+dynamic = ["classifiers", "dependencies", "optional-dependencies"]
+
+[project.urls]
+"Repository" = "https://github.com/bdraco/aiodiscover"
+"Documentation" = "https://aiodiscover.readthedocs.io"
+"Bug Tracker" = "https://github.com/bdraco/aiodiscover/issues"
+"Changelog" = "https://github.com/bdraco/aiodiscover/blob/main/CHANGELOG.md"
+
+[tool.poetry]
 classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: Apache Software License"
 ]
 packages = [
     { include = "aiodiscover" },
 ]
-
-[tool.poetry.urls]
-"Bug Tracker" = "https://github.com/bdraco/aiodiscover/issues"
-"Changelog" = "https://github.com/bdraco/aiodiscover/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
@@ -55,7 +54,7 @@ sphinx-autobuild = { version = ">=2024.0.0", python = ">=3.11"}
 
 
 [tool.semantic_release]
-version_toml = ["pyproject.toml:tool.poetry.version"]
+version_toml = ["pyproject.toml:project.version"]
 version_variables = [
     "aiodiscover/__init__.py:__version__",
 ]
@@ -177,5 +176,5 @@ module = "docs.*"
 ignore_errors = true
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Project metadata diff:
```diff
 ...
+License: Apache-2.0
-Requires-Python: >=3.9,<4.0
+Requires-Python: >=3.9
 ...
-Project-URL: Repository, https://github.com/uilibs/aiodiscover
+Project-URL: Repository, https://github.com/bdraco/aiodiscover
 ...
```

Updated the repository url as well to point to the correct location.