### PR TITLE
fix: only install async_timeout for python <3.11

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -58,6 +58,7 @@ description = "Timeout context manager for asyncio programs"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version < \"3.11\""
 files = [
     {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
     {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
@@ -1794,4 +1795,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "dfbbd3f5e99580e00a95c1446520d784ac108c4b08be33f87ff1ae8f9c124b06"
+content-hash = "3b26d3a3b7211a6a5272f5091dec5b4a1b30c3260696130d40026703c64da34d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-async_timeout = ">=4.0.1"
+async_timeout = { version = ">=4.0.1", python = "<3.11" }
 netifaces = ">=0.11.0"
 aiodns = ">=3.1.1"
 ifaddr = ">0.0.0"


### PR DESCRIPTION
https://github.com/bdraco/aiodiscover/blob/3c3f1a4d5145d5068fb96c2e6b9c7ce1b6075ba9/aiodiscover/util.py#L5-L8