### PR TITLE
feat: add cache of failed nameservers

### DIFF
--- a/aiodiscover/discovery.py
+++ b/aiodiscover/discovery.py
@@ -24,8 +24,8 @@ QUERY_BUCKET_SIZE = 64
 
 DNS_RESPONSE_TIMEOUT = 2
 
-# 12 hours
-CACHE_CLEAR_INTERVAL = 60 * 60 * 12
+# 24 hours
+CACHE_CLEAR_INTERVAL = 60 * 60 * 24
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/aiodiscover/discovery.py
+++ b/aiodiscover/discovery.py
@@ -116,9 +116,10 @@ class DiscoverHosts:
         the same nameservers over and over if they are unresponsive, but not
         to permanently skip them since they may become responsive again.
         """
-        if self._loop.time() - self._last_cache_clear > CACHE_CLEAR_INTERVAL:
+        now = self._loop.time()
+        if now - self._last_cache_clear > CACHE_CLEAR_INTERVAL:
             self._failed_nameservers.clear()
-            self._last_cache_clear = self._loop.time()
+            self._last_cache_clear = now
 
     async def async_discover(self) -> list[dict[str, str]]:
         """Discover hosts on the network by ARP and PTR lookup."""

--- a/aiodiscover/discovery.py
+++ b/aiodiscover/discovery.py
@@ -171,6 +171,9 @@ class DiscoverHosts:
     ) -> dict[str, str]:
         """Lookup PTR records for all addresses in the network."""
         all_nameservers = await self._async_get_nameservers(sys_network_data)
+        _LOGGER.debug("Using nameservers %s", all_nameservers)
+        _LOGGER.debug("Using network %s", sys_network_data.network)
+        _LOGGER.debug("Previous failed nameservers %s", self._failed_nameservers)
         ips = list(sys_network_data.network.hosts())
         hostnames: dict[str, str] = {}
         failed_nameservers_this_run: set[IPv4Address | IPv6Address] = set()
@@ -193,6 +196,7 @@ class DiscoverHosts:
                 # As soon as we have a responsive nameserver, there
                 # is no need to query additional fallbacks
                 break
+        _LOGGER.debug("Failed nameservers this run %s", failed_nameservers_this_run)
         if hostnames:
             # If we have any working nameservers, keep track of which
             # ones failed this run so we don't try them again

--- a/demo.py
+++ b/demo.py
@@ -3,6 +3,9 @@ import pprint
 
 from aiodiscover import DiscoverHosts
 
-discover_hosts = DiscoverHosts()
-hosts = asyncio.run(discover_hosts.async_discover())
-pprint.pprint(hosts)
+
+async def run() -> None:
+    pprint.pprint(DiscoverHosts().async_discover())
+
+
+asyncio.run(run())

--- a/demo.py
+++ b/demo.py
@@ -1,11 +1,14 @@
 import asyncio
+import logging
 import pprint
 
 from aiodiscover import DiscoverHosts
 
+logging.basicConfig(level=logging.DEBUG)
+
 
 async def run() -> None:
-    pprint.pprint(DiscoverHosts().async_discover())
+    pprint.pprint(await DiscoverHosts().async_discover())
 
 
 asyncio.run(run())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,8 @@ prerelease = true
 [tool.pytest.ini_options]
 addopts = "-v -Wdefault --cov=aiodiscover --cov-report=term-missing:skip-covered"
 pythonpath = ["src"]
+log_cli="true"
+log_level="NOTSET"
 
 [tool.coverage.run]
 branch = true
@@ -178,3 +180,5 @@ ignore_errors = true
 [build-system]
 requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+


### PR DESCRIPTION
In order to minimize network traffic, if a nameserver fails to respond, don't try it again for 24 hours.
