### PR TITLE
feat: drop unmaintained netifaces dependency

### DIFF
--- a/aiodiscover/network.py
+++ b/aiodiscover/network.py
@@ -115,11 +115,15 @@ def get_router_ip(ipr: IPRoute) -> IPv4Address | None:
     )
 
 
-def _get_macos_default_gateway() -> str | None:
-    """Get the default gateway IP on macOS via `route -n get default`."""
+def _get_macos_default_gateway(family: str = "inet") -> str | None:
+    """
+    Get the default gateway IP on macOS via `route -n get default`.
+
+    family: "inet" for IPv4, "inet6" for IPv6.
+    """
     try:
-        result = subprocess.run(
-            ["route", "-n", "get", "default"],  # noqa: S607
+        result = subprocess.run(  # noqa: S603
+            ["route", "-n", "get", f"-{family}", "default"],  # noqa: S607
             capture_output=True,
             text=True,
             timeout=2,
@@ -133,7 +137,8 @@ def _get_macos_default_gateway() -> str | None:
     for raw_line in result.stdout.splitlines():
         line = raw_line.strip()
         if line.startswith("gateway:"):
-            return line.split(":", 1)[1].strip() or None
+            # IPv6 gateways may include a zone suffix (e.g. fe80::1%en0)
+            return line.split(":", 1)[1].strip().split("%", 1)[0] or None
     return None
 
 

--- a/aiodiscover/network.py
+++ b/aiodiscover/network.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import re
 import socket
+import subprocess
 import sys
 from contextlib import suppress
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, ip_network
@@ -114,6 +115,27 @@ def get_router_ip(ipr: IPRoute) -> IPv4Address | None:
     )
 
 
+def _get_macos_default_gateway() -> str | None:
+    """Get the default gateway IP on macOS via `route -n get default`."""
+    try:
+        result = subprocess.run(
+            ["route", "-n", "get", "default"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if line.startswith("gateway:"):
+            return line.split(":", 1)[1].strip() or None
+    return None
+
+
 def _fill_neighbor(neighbours: dict[str, str], ip: str, mac: str) -> None:
     """Add a neighbor if it is valid."""
     if not (ip_addr := cached_ip_addresses(ip)):
@@ -183,14 +205,11 @@ class SystemNetworkData:
         if self.ip_route:
             with suppress(Exception):
                 self.router_ip = get_router_ip(self.ip_route)
-        if not self.router_ip:
-            # On MacOS netifaces is the only reliable way to get the default gateway
-            with suppress(Exception):
-                import netifaces  # type: ignore # pylint: disable=import-outside-toplevel
-
-                self.router_ip = cached_ip_addresses(
-                    netifaces.gateways()["default"][netifaces.AF_INET][0],
-                )
+        if not self.router_ip and sys.platform == "darwin":
+            # pyroute2 is Linux-only; on macOS parse `route -n get default`
+            gateway = _get_macos_default_gateway()
+            if gateway:
+                self.router_ip = cached_ip_addresses(gateway)
         if not self.router_ip:
             network_address = str(self.network.network_address)
             self.router_ip = cached_ip_addresses(f"{network_address[:-1]}1")

--- a/aiodiscover/network.py
+++ b/aiodiscover/network.py
@@ -124,6 +124,7 @@ def _get_macos_default_gateway() -> str | None:
             text=True,
             timeout=2,
             check=False,
+            close_fds=False,
         )
     except (OSError, subprocess.SubprocessError):
         return None

--- a/aiodiscover/tests/test_network.py
+++ b/aiodiscover/tests/test_network.py
@@ -97,6 +97,35 @@ def test_get_macos_default_gateway_oserror() -> None:
         assert _get_macos_default_gateway() is None
 
 
+def test_get_macos_default_gateway_ipv6_strips_zone() -> None:
+    """IPv6 default gateways may include a zone suffix like `%en0`."""
+    output = (
+        "   route to: default\n"
+        "destination: default\n"
+        "    gateway: fe80::1%en0\n"
+        "  interface: en0\n"
+    )
+    with patch(
+        "aiodiscover.network.subprocess.run",
+        return_value=_mock_run(output),
+    ) as mock_run:
+        assert _get_macos_default_gateway("inet6") == "fe80::1"
+    # Family argument must reach the route command.
+    args = mock_run.call_args[0][0]
+    assert "-inet6" in args
+
+
+def test_get_macos_default_gateway_default_family_is_inet() -> None:
+    with patch(
+        "aiodiscover.network.subprocess.run",
+        return_value=_mock_run(ROUTE_OUTPUT_WITH_GATEWAY),
+    ) as mock_run:
+        _get_macos_default_gateway()
+    args = mock_run.call_args[0][0]
+    assert "-inet" in args
+    assert "-inet6" not in args
+
+
 @pytest.mark.skipif(
     sys.platform != "darwin", reason="route -n get default is macOS-specific"
 )

--- a/aiodiscover/tests/test_network.py
+++ b/aiodiscover/tests/test_network.py
@@ -2,8 +2,10 @@
 import asyncio
 import subprocess
 import sys
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import IPv4Address, IPv6Address, ip_address
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from aiodiscover.network import _get_macos_default_gateway, parse_resolv_conf
 
@@ -93,3 +95,17 @@ def test_get_macos_default_gateway_oserror() -> None:
         side_effect=FileNotFoundError(),
     ):
         assert _get_macos_default_gateway() is None
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin", reason="route -n get default is macOS-specific"
+)
+def test_get_macos_default_gateway_e2e() -> None:
+    """End-to-end: actually run `route -n get default` and verify parsing."""
+    result = _get_macos_default_gateway()
+    if result is None:
+        # No default gateway (e.g. VPN-only default route or no network) is a
+        # valid outcome; the function must not raise.
+        return
+    # Anything returned must be a parseable IP address.
+    ip_address(result)

--- a/aiodiscover/tests/test_network.py
+++ b/aiodiscover/tests/test_network.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 import asyncio
+import subprocess
 import sys
 from ipaddress import IPv4Address, IPv6Address
+from unittest.mock import MagicMock, patch
 
-from aiodiscover.network import parse_resolv_conf
+from aiodiscover.network import _get_macos_default_gateway, parse_resolv_conf
 
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -26,3 +28,68 @@ def test_parse_resolv_conf() -> None:
         IPv4Address("32.2.1.1"),
         IPv6Address("2001:4860:4860::8888"),
     ]
+
+
+ROUTE_OUTPUT_WITH_GATEWAY = """\
+   route to: default
+destination: default
+       mask: default
+    gateway: 192.168.1.1
+  interface: en0
+      flags: <UP,GATEWAY,DONE,STATIC,PRMRY>
+"""
+
+ROUTE_OUTPUT_NO_GATEWAY = """\
+   route to: default
+destination: default
+       mask: default
+  interface: utun5
+      flags: <UP,DONE,CLONING,STATIC,GLOBAL>
+"""
+
+
+def _mock_run(stdout: str, returncode: int = 0) -> MagicMock:
+    mock = MagicMock()
+    mock.stdout = stdout
+    mock.returncode = returncode
+    return mock
+
+
+def test_get_macos_default_gateway_parses_gateway_line() -> None:
+    with patch(
+        "aiodiscover.network.subprocess.run",
+        return_value=_mock_run(ROUTE_OUTPUT_WITH_GATEWAY),
+    ):
+        assert _get_macos_default_gateway() == "192.168.1.1"
+
+
+def test_get_macos_default_gateway_no_gateway_line() -> None:
+    with patch(
+        "aiodiscover.network.subprocess.run",
+        return_value=_mock_run(ROUTE_OUTPUT_NO_GATEWAY),
+    ):
+        assert _get_macos_default_gateway() is None
+
+
+def test_get_macos_default_gateway_nonzero_exit() -> None:
+    with patch(
+        "aiodiscover.network.subprocess.run",
+        return_value=_mock_run("", returncode=1),
+    ):
+        assert _get_macos_default_gateway() is None
+
+
+def test_get_macos_default_gateway_subprocess_error() -> None:
+    with patch(
+        "aiodiscover.network.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="route", timeout=2),
+    ):
+        assert _get_macos_default_gateway() is None
+
+
+def test_get_macos_default_gateway_oserror() -> None:
+    with patch(
+        "aiodiscover.network.subprocess.run",
+        side_effect=FileNotFoundError(),
+    ):
+        assert _get_macos_default_gateway() is None

--- a/poetry.lock
+++ b/poetry.lock
@@ -975,46 +975,6 @@ testing = ["beautifulsoup4", "coverage[toml]", "defusedxml", "pygments (<2.19)",
 testing-docutils = ["pygments", "pytest (>=8,<9)", "pytest-param-files (>=0.6.0,<0.7.0)"]
 
 [[package]]
-name = "netifaces"
-version = "0.11.0"
-description = "Portable network interface information."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "netifaces-0.11.0-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eb4813b77d5df99903af4757ce980a98c4d702bbcb81f32a0b305a1537bdf0b1"},
-    {file = "netifaces-0.11.0-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:5f9ca13babe4d845e400921973f6165a4c2f9f3379c7abfc7478160e25d196a4"},
-    {file = "netifaces-0.11.0-cp27-cp27m-win32.whl", hash = "sha256:7dbb71ea26d304e78ccccf6faccef71bb27ea35e259fb883cfd7fd7b4f17ecb1"},
-    {file = "netifaces-0.11.0-cp27-cp27m-win_amd64.whl", hash = "sha256:0f6133ac02521270d9f7c490f0c8c60638ff4aec8338efeff10a1b51506abe85"},
-    {file = "netifaces-0.11.0-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:08e3f102a59f9eaef70948340aeb6c89bd09734e0dca0f3b82720305729f63ea"},
-    {file = "netifaces-0.11.0-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c03fb2d4ef4e393f2e6ffc6376410a22a3544f164b336b3a355226653e5efd89"},
-    {file = "netifaces-0.11.0-cp34-cp34m-win32.whl", hash = "sha256:73ff21559675150d31deea8f1f8d7e9a9a7e4688732a94d71327082f517fc6b4"},
-    {file = "netifaces-0.11.0-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:815eafdf8b8f2e61370afc6add6194bd5a7252ae44c667e96c4c1ecf418811e4"},
-    {file = "netifaces-0.11.0-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:50721858c935a76b83dd0dd1ab472cad0a3ef540a1408057624604002fcfb45b"},
-    {file = "netifaces-0.11.0-cp35-cp35m-win32.whl", hash = "sha256:c9a3a47cd3aaeb71e93e681d9816c56406ed755b9442e981b07e3618fb71d2ac"},
-    {file = "netifaces-0.11.0-cp36-cp36m-macosx_10_15_x86_64.whl", hash = "sha256:aab1dbfdc55086c789f0eb37affccf47b895b98d490738b81f3b2360100426be"},
-    {file = "netifaces-0.11.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c37a1ca83825bc6f54dddf5277e9c65dec2f1b4d0ba44b8fd42bc30c91aa6ea1"},
-    {file = "netifaces-0.11.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:28f4bf3a1361ab3ed93c5ef360c8b7d4a4ae060176a3529e72e5e4ffc4afd8b0"},
-    {file = "netifaces-0.11.0-cp36-cp36m-win32.whl", hash = "sha256:2650beee182fed66617e18474b943e72e52f10a24dc8cac1db36c41ee9c041b7"},
-    {file = "netifaces-0.11.0-cp36-cp36m-win_amd64.whl", hash = "sha256:cb925e1ca024d6f9b4f9b01d83215fd00fe69d095d0255ff3f64bffda74025c8"},
-    {file = "netifaces-0.11.0-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:84e4d2e6973eccc52778735befc01638498781ce0e39aa2044ccfd2385c03246"},
-    {file = "netifaces-0.11.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:18917fbbdcb2d4f897153c5ddbb56b31fa6dd7c3fa9608b7e3c3a663df8206b5"},
-    {file = "netifaces-0.11.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:48324183af7f1bc44f5f197f3dad54a809ad1ef0c78baee2c88f16a5de02c4c9"},
-    {file = "netifaces-0.11.0-cp37-cp37m-win32.whl", hash = "sha256:8f7da24eab0d4184715d96208b38d373fd15c37b0dafb74756c638bd619ba150"},
-    {file = "netifaces-0.11.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2479bb4bb50968089a7c045f24d120f37026d7e802ec134c4490eae994c729b5"},
-    {file = "netifaces-0.11.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:3ecb3f37c31d5d51d2a4d935cfa81c9bc956687c6f5237021b36d6fdc2815b2c"},
-    {file = "netifaces-0.11.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:96c0fe9696398253f93482c84814f0e7290eee0bfec11563bd07d80d701280c3"},
-    {file = "netifaces-0.11.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c92ff9ac7c2282009fe0dcb67ee3cd17978cffbe0c8f4b471c00fe4325c9b4d4"},
-    {file = "netifaces-0.11.0-cp38-cp38-win32.whl", hash = "sha256:d07b01c51b0b6ceb0f09fc48ec58debd99d2c8430b09e56651addeaf5de48048"},
-    {file = "netifaces-0.11.0-cp38-cp38-win_amd64.whl", hash = "sha256:469fc61034f3daf095e02f9f1bbac07927b826c76b745207287bc594884cfd05"},
-    {file = "netifaces-0.11.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:5be83986100ed1fdfa78f11ccff9e4757297735ac17391b95e17e74335c2047d"},
-    {file = "netifaces-0.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:54ff6624eb95b8a07e79aa8817288659af174e954cca24cdb0daeeddfc03c4ff"},
-    {file = "netifaces-0.11.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:841aa21110a20dc1621e3dd9f922c64ca64dd1eb213c47267a2c324d823f6c8f"},
-    {file = "netifaces-0.11.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e76c7f351e0444721e85f975ae92718e21c1f361bda946d60a214061de1f00a1"},
-    {file = "netifaces-0.11.0.tar.gz", hash = "sha256:043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32"},
-]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
@@ -1738,15 +1698,15 @@ test = ["pytest"]
 
 [[package]]
 name = "starlette"
-version = "0.49.1"
+version = "1.0.0"
 description = "The little ASGI library that shines."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["docs"]
 markers = "python_version >= \"3.11\""
 files = [
-    {file = "starlette-0.49.1-py3-none-any.whl", hash = "sha256:d92ce9f07e4a3caa3ac13a79523bd18e3bc0042bb8ff2d759a8e7dd0e1859875"},
-    {file = "starlette-0.49.1.tar.gz", hash = "sha256:481a43b71e24ed8c43b11ea02f5353d77840e01480881b8cb5a26b8cae64a8cb"},
+    {file = "starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"},
+    {file = "starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149"},
 ]
 
 [package.dependencies]
@@ -2047,4 +2007,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "381d1ce254b45a661028d1f851c8aa3c79dd5cf2bcd8a1e25e6d59ff181852bd"
+content-hash = "8b0e46531bf2dc1a3bce79f3d74920415e37818bde1aa9b84f27a3d597f8442a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 async_timeout = { version = ">=4.0.1", python = "<3.11" }
-netifaces = ">=0.11.0"
 aiodns = ">=3.1.1"
 ifaddr = ">0.0.0"
 pyroute2 = ">=0.9.6"


### PR DESCRIPTION
## Summary

- Drop the `netifaces` dependency entirely
- The only use was a macOS fallback for discovering the default gateway when `pyroute2` (Linux-only via netlink) is unavailable
- Replace it with a small subprocess call to `route -n get default`, which ships with macOS by default

## Motivation

`netifaces` has been archived for years. Forks (e.g. `netifaces-plus`) ship a top-level `netifaces` module, which means installing them alongside the original — or alongside any other transitive consumer of `netifaces` — causes file collisions in `site-packages` (pip sees two different distributions providing the same import name with no conflict detection). The fork itself recommends switching to `ifaddr`, which this project already uses for everything else.

Removing the dep avoids the conflict entirely.

## Behavior

- Linux: unchanged — `pyroute2` provides the default gateway via netlink as before.
- macOS: `route -n get default` is parsed for the `gateway:` line. 2s timeout, errors silently ignored.
- Other platforms (Windows, BSDs): fall through to the existing heuristic (`network_address[:-1] + 1`). Previously these would have tried the `netifaces` fallback; the heuristic is the same fallback that has always applied when both pyroute2 and netifaces failed.

## Test plan

- [x] New unit tests cover the parser with a real-looking gateway line, a no-gateway (VPN-only default route) line, non-zero exit, `TimeoutExpired`, and `FileNotFoundError` (missing `route` binary)
- [x] Full existing test suite passes locally
- [ ] Confirm HA builds against the new release without pulling `netifaces` transitively

closes #183.