### PR TITLE
chore: enable pyupgrade UP rules for py310-plus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,8 +120,6 @@ ignore = [
     "B008", # Do not perform function call
     "S110", # `try`-`except`-`pass` detected, consider logging the exception
     "D106", # Missing docstring in public nested class
-    "UP007", # typer needs Optional syntax
-    "UP038", # Use `X | Y` in `isinstance` is slower
 ]
 select = [
     "B",   # flake8-bugbear


### PR DESCRIPTION
## Summary

Now that Python 3.9 support has been dropped (#191), enable the full pyupgrade ruleset by removing the two stale entries from ruff's ignore list:

- `UP007` — originally suppressed for a typer dependency; not applicable here, and no `Union[…]`/`Optional[…]` patterns exist in the codebase.
- `UP038` — removed from ruff in a recent version; ignoring it was a no-op that produced a deprecation warning on every run.

`tool.ruff.target-version` is already `py310`, so all `UP` checks now apply at the py310-plus level.

## Test plan

- [x] `pre-commit run --all-files` is clean
- [x] Full test suite passes locally (18 tests)