### PR TITLE
ci: add Python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         os:
           - windows-latest
           - ubuntu-latest


### PR DESCRIPTION
## Summary

Adds Python 3.14 to the CI test matrix alongside 3.10–3.13.

## Test plan

- [ ] CI exercises 3.14 across linux/macOS/windows