### PR TITLE
ci: push releases via SSH deploy key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,14 @@ jobs:
       contents: write
 
     steps:
+      # Check out using the deploy key so PSR's later commit/tag push goes
+      # through SSH as the deploy-key actor — which is in the branch
+      # ruleset's bypass_actors list.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Create local branch name
         run: git switch -C ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary

Authenticate the release checkout with an SSH deploy key so PSR's commit/tag push to `main` is performed by the deploy-key actor, which has bypass on the `passing checks` ruleset. Fixes the recurring `GH013: Repository rule violations` failure on the release job.

## Test plan

- [ ] Merge and confirm the next release pushes the version-bump commit + tag to `main` and uploads to PyPI.