### PR TITLE
fix(ci): scope release environment to main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
       - commitlint
 
     runs-on: ubuntu-latest
-    environment: release
+    # Only enter the protected 'release' environment when actually releasing
+    # from main; PR dry-runs would otherwise be blocked by the env's
+    # main-only branch policy.
+    environment: ${{ github.ref_name == 'main' && 'release' || '' }}
     concurrency: release
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

PR builds now fail with `Branch "refs/pull/N/merge" is not allowed to deploy to release due to environment protection rules` because the release env is locked to main but the job declares `environment: release` unconditionally.

Make the env reference conditional: PR dry-runs enter no environment, main releases still enter `release`.

## Test plan

- [ ] This PR's own CI run no longer errors on the release job
- [ ] Merging to main still enters the `release` environment and publishes