### PR TITLE
ci: add pytest-timeout with 90s timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ addopts = "-v -Wdefault --cov=aiodiscover --cov-report=term-missing:skip-covered
 pythonpath = ["src"]
 log_cli="true"
 log_level="NOTSET"
+timeout = 90
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## Summary
- Enable `pytest-timeout` (already in dev deps) by setting `timeout = 90` in `[tool.pytest.ini_options]` so hung tests in CI fail fast instead of running until the workflow's job-level timeout.

## Test plan
- [ ] CI completes within the new per-test limit.