### PR TITLE
docs: add CLAUDE.md and pr-workflow skill for LLM contributors

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: pr-workflow
+description: Create pull requests for bluetooth-devices/aiodiscover. Use when creating PRs, submitting changes, or preparing contributions.
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# aiodiscover PR Workflow
+
+When creating a pull request for `bluetooth-devices/aiodiscover`,
+follow these steps. Repo-wide conventions live in
+[CLAUDE.md](../../../CLAUDE.md); this skill summarises the parts
+that matter at PR-creation time.
+
+## 1. Create branch from origin/main
+
+`origin` points at `bluetooth-devices/aiodiscover`; there is no
+fork in this workflow. Always re-fetch first so the branch is
+based on the latest `main`:
+
+```bash
+git fetch origin
+git checkout -b <branch-name> origin/main
+```
+
+`CONTRIBUTING.md` suggests branch names of the form
+`{type}/short-description` (e.g. `feature/read-tiff-files`,
+`bugfix/handle-file-not-found`). It's a soft convention — not
+enforced by CI — but match it when convenient.
+
+## 2. Conventional Commits — for both commit subjects AND PR title
+
+Every commit subject MUST follow
+[Conventional Commits](https://www.conventionalcommits.org/), and
+the PR title should too. The CI gate is the per-commit
+`commitlint` job in `.github/workflows/ci.yml` (running
+`wagoid/commitlint-github-action` against
+`@commitlint/config-conventional`).
+
+Unlike some sibling repos, **there is no separate
+`pr-title.yml` workflow** — only the per-commit linter runs.
+GitHub still uses the PR title as the squash-merge commit
+subject, so a malformed title becomes a malformed commit on
+`main`, which `python-semantic-release` will then either
+miscategorise or skip. Treat the PR title with the same care
+as a commit subject.
+
+Accepted types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`,
+`perf`, `refactor`, `revert`, `style`, `test`. Scope is optional.
+The subject (text after `type(scope):`) must start lowercase.
+`commitlint.config.mjs` explicitly disables header / body /
+footer length limits, so long subjects won't fail CI — but keep
+them readable. Examples that pass:
+
+```
+feat: add async context manager to DiscoverHosts
+fix(network): fall back to arp -an on macOS when pyroute2 is missing
+perf!: drop python 3.10 support
+```
+
+### Pick the type that matches the release impact
+
+`python-semantic-release` reads the commit log on `main` to
+decide the next version, write `CHANGELOG.md`, bump
+`pyproject.toml:project.version` and
+`aiodiscover/__init__.py:__version__`, tag, push, and publish to
+PyPI:
+
+| Type                                                               | Release effect                                  |
+| ------------------------------------------------------------------ | ----------------------------------------------- |
+| `feat:`                                                            | minor bump, shows in changelog under Features   |
+| `fix:`, `perf:`                                                    | patch bump, shows under Bug Fixes / Performance |
+| any with `!` or `BREAKING CHANGE:` footer                          | major bump                                      |
+| `chore:`, `docs:`, `test:`, `ci:`, `style:`, `build:`, `refactor:` | no bump                                         |
+
+`chore*` and `ci*` are also stripped from the changelog
+entirely (see `exclude_commit_patterns` in
+`[tool.semantic_release.changelog]` in `pyproject.toml`). A
+user-visible bugfix tagged `chore:` will be silently omitted
+from the changelog; an internal refactor tagged `feat!:` will
+mint a fake major release. Pick the type a changelog reader
+would expect.
+
+## 3. Fill in the PR template
+
+Unlike `dbus-fast`, this repo **does** ship
+`.github/PULL_REQUEST_TEMPLATE.md`. It has two sections:
+
+- **Description of change** — what the change does, why, and
+  how you verified it. Use `Fixes #N` (or `closes #N`) here so
+  GitHub auto-closes the issue on merge. If the change is
+  related to an issue but doesn't close it, just reference the
+  number without the keyword.
+- **Pull-Request Checklist** — six tickboxes (up-to-date with
+  `main`, follows contributing guidelines, links issues with
+  `Fixes #N`, has new/updated unit tests, docs updated,
+  Conventional Commits). The template's own comment notes that
+  unchecked boxes are fine when the PR opens, and `N/A` is an
+  acceptable answer for any item that doesn't apply (e.g. a
+  pure docs change doesn't need new unit tests).
+
+Don't delete the template structure — fill it in. Reviewers
+expect to see those headings.
+
+## 4. Commit hygiene
+
+- **Imperative-mood subject line** — "add X", not "added X".
+  Lowercase first word (commitlint rule).
+- **No `Co-Authored-By` trailers for LLM tools.** Project
+  preference — commits attribute the human who reviewed the
+  change.
+- **Don't hand-edit `__version__` or `project.version`.**
+  `python-semantic-release` owns both and will overwrite manual
+  edits on the next release.
+- Let pre-commit run (commitizen on `commit-msg`, plus ruff
+  lint + format, prettier, codespell, mypy, and the standard
+  `pre-commit-hooks` set on `pre-commit`). If a hook auto-fixes
+  a file, the commit aborts — re-stage the auto-fixed files and
+  re-commit. The full hook list is in `.pre-commit-config.yaml`.
+- Write tests for behavioural changes — they live **inside**
+  the package at `aiodiscover/tests/` (not at a top-level
+  `tests/` directory). Tests are mocked end-to-end; no network
+  or system services are required:
+
+  ```bash
+  poetry run pytest
+  ```
+
+  `addopts` in `pyproject.toml` already enables verbose mode
+  and coverage against `aiodiscover` — no extra flags needed.
+
+## 5. Push and create the PR
+
+```bash
+git push -u origin <branch-name>
+gh pr create --repo bluetooth-devices/aiodiscover --base main \
+  --title "type(scope): lowercase subject" \
+  --body-file /tmp/pr-body.md
+```
+
+Use `--body-file` rather than `--body "..."` so that backticks,
+asterisks, and other Markdown in the body are passed through
+verbatim instead of being mangled by shell quoting.
+
+If the title fails the per-commit `commitlint` check on the
+squash-merge commit (which would only surface when a maintainer
+hits "Squash and merge"), you can fix it in the GitHub UI or
+with `gh pr edit --title "..."`; no push is needed.
+
+## 6. After the PR is open
+
+The CI workflow `.github/workflows/ci.yml` runs four jobs:
+
+- **`lint`** — pre-commit on Python 3.x (ruff lint + format,
+  prettier, codespell, mypy, and the standard hooks).
+- **`commitlint`** — per-commit Conventional Commits check
+  via `wagoid/commitlint-github-action@v6.2.1`, with
+  `fetch-depth: 0` so it can walk the branch.
+- **`test`** matrix — Python 3.10, 3.11, 3.12, 3.13, 3.14 ×
+  ubuntu-latest, macOS-latest, windows-latest (15 cells, all
+  required green). Coverage is uploaded to Codecov.
+- **`release`** — needs all three above. On PRs from non-main
+  branches it does a `python-semantic-release` dry run
+  (`no_operation_mode: true`); on `main` after merge it does
+  the real release: bumps versions, writes `CHANGELOG.md`, tags,
+  pushes via the SSH deploy key, and uploads to PyPI as well as
+  GitHub Releases.
+
+A red `lint` job is usually the pre-commit auto-fix you forgot
+to re-stage. A red cell only on Windows or macOS in the `test`
+matrix usually means a Linux-only path leaked into a code path
+that should be platform-agnostic — check `aiodiscover/network.py`
+for the `sys.platform` / try-import pattern. A red cell only on
+Python 3.10 usually means a 3.11+ stdlib import slipped in
+without going through the `aiodiscover/util.py` shim.
+
+Dependabot PRs are auto-merged by `.github/workflows/auto-merge.yml`
+once CI is green; human PRs are not. Plan on a manual review,
+followed by a "Squash and merge" step.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,311 @@
+# Notes for LLM contributors
+
+A short orientation file for an LLM working in this repo. Skim
+before making changes; keep edits consistent with what's described
+here. Read [README.md](README.md) for the user-facing intro and
+[CONTRIBUTING.md](CONTRIBUTING.md) for the human contributor flow
+(but note that some of `CONTRIBUTING.md` is stale — see
+_Documentation drift_ below).
+
+## What this project is
+
+`aiodiscover` is a small, async Python library that enumerates
+hosts on the local network by combining two sources:
+
+- **ARP table walks** — populated by sending probe traffic to
+  every address in the local subnet, then reading the system ARP
+  cache via `pyroute2` on Linux or `arp -an` on macOS / Windows.
+- **DNS PTR lookups** — the discovered IPs are reverse-resolved
+  via `aiodns` against the system resolver to recover hostnames.
+
+The public surface is a single class — `DiscoverHosts` (in
+`aiodiscover/discovery.py`) — exposing one coroutine,
+`async_discover()`, that returns a list of
+`{hostname, ip, macaddress}` dicts.
+
+The most important downstream user is
+[Home Assistant](https://www.home-assistant.io/), which calls
+`async_discover()` from its `dhcp` integration to find devices on
+the user's LAN. That makes a few things load-bearing:
+
+- The library runs on **Linux, macOS, and Windows** — the CI
+  matrix covers all three. Anything Linux-specific (notably
+  `pyroute2`) lives behind `sys.platform` / try-import guards in
+  `aiodiscover/network.py`.
+- It runs against **whatever DNS resolver the user has
+  configured**, including public resolvers like Quad9 / 1.1.1.1.
+  Excessive or malformed PTR queries can get end users
+  rate-limited or banned upstream — be conservative with query
+  volume and resolver behaviour. (See `fix_ptr_recursion.py` at
+  the repo root for an in-progress investigation into adding
+  `ARES_FLAG_NORECURSE` to suppress recursion on PTR lookups.)
+- It must not import or fail on missing optional Linux-only
+  dependencies on macOS / Windows.
+
+## Code style
+
+- **Docstrings: terse, default to single-line.** A docstring is
+  the function's _contract_, not its narrative. Almost every
+  docstring should be one line — `"""Summary."""` — describing
+  what the function does. Multi-line is the exception, only
+  justified when there is non-obvious caller-visible behaviour
+  the type signature and parameter names don't already convey.
+
+  **What does NOT belong in docstrings or comments:**
+  - Rationale / motivation / "why we used to do X" — that's the
+    PR description and the commit message. Git already remembers.
+  - Cross-references to issue numbers ("closes #N", "follow-up
+    to #M") — the PR body carries those.
+  - Restatement of the function body in prose. If the next line
+    of the docstring is just describing what the next line of
+    code does, delete the docstring line.
+  - Test docstrings retelling the production-side story. A test
+    docstring should name what the test pins, in one sentence —
+    not re-explain the bug, the fix, or the surrounding flow.
+
+- **Comments**: same bar. Default to writing no comments. Add
+  one only when the _why_ is non-obvious: a hidden constraint, a
+  subtle invariant, a workaround for a specific bug, behaviour
+  that would surprise a reader. If removing the comment wouldn't
+  confuse a future reader, don't write it.
+
+  **Don't remove existing comments** unless the code they
+  describe is gone — the original author left them for a reason.
+  In particular, the `sys.platform` and `try`/`except ImportError`
+  branches in `network.py` exist _because_ removing them broke
+  the macOS / Windows test legs.
+
+- **Method order**: public API at the top, private helpers
+  (`_underscore_prefixed`) at the bottom.
+
+- **Line length**: 88 (ruff default; configured in
+  `pyproject.toml`). `requires-python = ">=3.10"`,
+  `target-version = "py310"` for ruff and the implicit floor for
+  `pyupgrade` (ruff's `UP` rules). Don't introduce 3.11+-only
+  syntax — for example, `aiodiscover/util.py` exists solely to
+  paper over `asyncio.timeout` not being available on 3.10. The
+  pattern is:
+
+  ```python
+  if sys.version_info[:2] < (3, 11):
+      from async_timeout import timeout as asyncio_timeout
+  else:
+      from asyncio import timeout as asyncio_timeout
+  ```
+
+  If you need a stdlib feature added in 3.11 or later, route it
+  through a similar shim rather than dropping 3.10 support.
+
+- **Imports**: ruff-isort sorted, with
+  `known-first-party = ["aiodiscover", "tests"]`. Prefer absolute
+  imports rooted at `aiodiscover.*`. Use
+  `from __future__ import annotations` — every existing module
+  under `aiodiscover/` does, which lets the type hints evaluate
+  lazily under 3.10.
+
+- **Typing**: mypy runs in strict mode (`disallow_untyped_defs`,
+  `disallow_incomplete_defs`, `disallow_any_generics`,
+  `warn_unreachable`, `warn_unused_ignores`). New production
+  code must be fully typed; tests are exempted via the
+  `tests.*` override in `pyproject.toml`.
+
+## Commit / PR conventions
+
+- **Conventional Commits, lowercase subject.** The repo runs
+  `@commitlint/config-conventional` on every commit (via the
+  `commitlint` CI job in `ci.yml` using
+  `wagoid/commitlint-github-action`, plus the `commitizen`
+  pre-commit hook on `commit-msg`). Accepted types: `build`,
+  `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`,
+  `revert`, `style`, `test`. Scopes are optional. The subject
+  (text after `type(scope):`) must start lowercase. Header,
+  body, and footer length limits are explicitly disabled in
+  `commitlint.config.mjs`, but still keep subject lines
+  readable. Examples that pass:
+  - `feat: add async context manager to DiscoverHosts`
+  - `fix(network): fall back to arp -an on macOS when pyroute2 is missing`
+  - `perf!: drop python 3.10 support`
+
+- **No separate PR-title gate.** Unlike some sibling repos
+  (e.g. `dbus-fast`), this repo does **not** run
+  `amannn/action-semantic-pull-request` on the PR title — only
+  the per-commit `commitlint` job runs. That said, GitHub uses
+  the PR title as the squash-merge subject, so it ends up in
+  the commit log on `main` and **must still parse as a valid
+  Conventional Commit** for the next `python-semantic-release`
+  run to classify it correctly. Treat the PR title with the
+  same care as a commit subject.
+
+- **Releases are commit-driven.** `python-semantic-release`
+  (configured in `pyproject.toml` under `[tool.semantic_release]`)
+  runs from the `release` job in `ci.yml` after `test`, `lint`,
+  and `commitlint` pass on `main`. It reads the commit log,
+  decides the next version, bumps `pyproject.toml`'s
+  `project.version` and `aiodiscover/__init__.py:__version__`,
+  writes `CHANGELOG.md`, tags, pushes, uploads to PyPI via
+  `pypa/gh-action-pypi-publish`, and attaches artefacts to a
+  GitHub release. Bump rules:
+  - `feat:` → minor bump.
+  - `fix:` / `perf:` → patch bump.
+  - Anything with `!` or a `BREAKING CHANGE:` footer → major.
+  - `chore:`, `docs:`, `test:`, `ci:`, `style:`, `build:`,
+    `refactor:` → no bump.
+  - `chore*` and `ci*` are also stripped from the changelog
+    entirely (`exclude_commit_patterns` in
+    `[tool.semantic_release.changelog]`). A user-visible bugfix
+    tagged `chore:` will be silently omitted from the
+    changelog — pick the type a changelog reader would expect.
+
+- **No `Co-Authored-By` trailers for LLM authorship.** Project
+  preference: commits attribute the human who reviewed the
+  change, not the tool that produced the draft.
+
+- **There IS a PR template** at
+  `.github/PULL_REQUEST_TEMPLATE.md` — a description block plus
+  a checklist (code up-to-date with `main`, follows
+  contributing guidelines, links issues with `Fixes #N`, has
+  unit tests, docs updated, commits follow Conventional
+  Commits). Fill in the description block; the checklist items
+  may be ticked or marked `N/A` per the template's own note.
+
+- **Pre-commit auto-fixes; re-stage.** `ruff --fix`,
+  `ruff-format`, `prettier`, `codespell`, `mypy`, and the
+  standard `pre-commit-hooks` set
+  (trailing-whitespace, end-of-file-fixer, debug-statements,
+  check-yaml/json/toml/xml, check-builtin-literals,
+  check-case-conflict, check-docstring-first,
+  detect-private-key) all run on commit and will modify files
+  in place. When a hook rewrites a file, the commit aborts —
+  re-stage the auto-fixed files and commit again.
+
+## Running tests
+
+The suite is pure-Python and self-contained — no network,
+no system services required (the network calls are mocked).
+Just:
+
+```bash
+poetry install
+poetry run pytest
+```
+
+`addopts` in `pyproject.toml` already enables verbose mode,
+coverage against `aiodiscover`, and term-missing reporting, so
+you don't need to pass extra flags for the normal flow. Tests
+use `pytest.mark.asyncio` (one mark per test) — see
+`aiodiscover/tests/test_discovery.py` for the pattern.
+
+The CI matrix (`.github/workflows/ci.yml`) runs Python
+**3.10, 3.11, 3.12, 3.13, 3.14** on **ubuntu-latest,
+macOS-latest, windows-latest** — fifteen cells, all required
+green. Most regressions you'll see in CI but not locally are
+one of:
+
+- A 3.11+ stdlib import that you forgot to gate via
+  `aiodiscover/util.py`-style shim.
+- A Linux-only code path (`pyroute2`, `/proc`,
+  `subprocess` invocation of `ip`/`arp`) that wasn't guarded.
+  `aiodiscover/network.py` already does the platform branching;
+  follow its pattern.
+- A test that assumed a POSIX `subprocess` quoting model and
+  fails under Windows. The Windows leg sets the
+  `WindowsSelectorEventLoopPolicy` in
+  `aiodiscover/tests/test_discovery.py`; if you add new
+  network-touching tests, mock at the same boundary the
+  existing tests do.
+
+## Build conventions
+
+- **Pure Python, Poetry.** `[build-system]` uses
+  `poetry-core>=2.0.0`; there's no Cython, no C extension, no
+  `build_ext.py`. `poetry build` produces both an sdist and a
+  wheel directly.
+- **Single source for the version.** `__version__` in
+  `aiodiscover/__init__.py` and `project.version` in
+  `pyproject.toml` are kept in sync by
+  `python-semantic-release`. Don't edit either by hand —
+  semantic-release will overwrite both during the release job.
+- **Runtime dependencies are pinned to floors, not ceilings**
+  in `pyproject.toml`: `aiodns>=3.1.1`, `ifaddr>0.0.0`,
+  `pyroute2>=0.9.6`, `cached_ipaddress>=0.2.0`. The one
+  conditional is `async_timeout = { version = ">=4.0.1",
+python = "<3.11" }` — needed only for the 3.10 leg, paired
+  with the shim in `aiodiscover/util.py`.
+- **Test-only dependencies** live in
+  `[tool.poetry.group.dev.dependencies]`. Docs deps live in
+  `[tool.poetry.group.docs.dependencies]` and are marked
+  `optional = true`, gated to Python 3.11+.
+
+## Useful entry points
+
+| Path                                  | What                                                                  |
+| ------------------------------------- | --------------------------------------------------------------------- |
+| `aiodiscover/__init__.py`             | Package entry point — re-exports `DiscoverHosts`, holds `__version__` |
+| `aiodiscover/discovery.py`            | `DiscoverHosts` class + DNS PTR resolution + chunking / batching      |
+| `aiodiscover/network.py`              | `SystemNetworkData` — ARP + interface enumeration; platform branches  |
+| `aiodiscover/util.py`                 | `asyncio_timeout` compat shim (3.10 → `async_timeout`, 3.11+ stdlib)  |
+| `aiodiscover/tests/test_discovery.py` | Tests for `DiscoverHosts` and the DNS PTR pipeline                    |
+| `aiodiscover/tests/test_network.py`   | Tests for ARP cache reading and interface enumeration                 |
+| `aiodiscover/tests/test_init.py`      | Smoke test for top-level imports                                      |
+| `aiodiscover/tests/conftest.py`       | Shared pytest fixtures                                                |
+| `pyproject.toml`                      | Poetry config + ruff / mypy / pytest / semantic-release settings      |
+| `commitlint.config.mjs`               | Conventional Commits config (header/body/footer length limits off)    |
+| `.pre-commit-config.yaml`             | Pre-commit hook set (commitizen, ruff, mypy, prettier, codespell, …)  |
+| `.github/workflows/ci.yml`            | Lint + commitlint + matrix tests + semantic-release / PyPI publish    |
+| `.github/PULL_REQUEST_TEMPLATE.md`    | PR template — description + checklist                                 |
+
+## Documentation drift
+
+A few committed docs are older than the current toolchain.
+Trust `pyproject.toml` and `.github/workflows/ci.yml` over
+prose in the following:
+
+- `CONTRIBUTING.md` describes a `pip install -e .[dev]` /
+  `make build` (tox) / `bump2version` flow. The actual flow is
+  Poetry + `poetry run pytest` + automatic versioning by
+  `python-semantic-release`. The high-level intent (fork,
+  branch, PR, Conventional Commits) is still correct.
+- `tox.ini` lists `py37, py38, py39` and uses `flake8` /
+  `black` — none of which match current reality (3.10–3.14, ruff).
+  It's effectively dead; `pytest` is invoked directly by CI.
+- `Makefile`'s `build` target shells out to `tox`, so it
+  inherits the same staleness. `make docs` / `make gen-docs`
+  are still useful for the Sphinx docs.
+- `README.md`'s "The Four Commands You Need To Know" section
+  is cookiecutter boilerplate and references Python 3.7 / 3.8
+  and `bump2version`. Don't mirror its phrasing in new docs.
+
+## Things not to do
+
+- **Don't introduce 3.11+-only syntax or stdlib imports** — the
+  package supports 3.10+. If you need an asyncio feature added
+  in 3.11+, follow the `aiodiscover/util.py` shim pattern.
+- **Don't remove the platform guards in `network.py`** —
+  `pyroute2` is Linux-only, the `arp -an` fallback is for
+  macOS / Windows, and the Windows test leg specifically pins
+  `WindowsSelectorEventLoopPolicy`. The CI matrix will fail
+  loudly if any of these regress, but the failures aren't
+  always intuitive to debug from the Linux dev box.
+- **Don't pick a Conventional Commit type that under- or over-
+  states the release impact.** `chore:` for a user-visible
+  bugfix hides it from the changelog (`chore*` is in
+  `exclude_commit_patterns`); `feat!:` for an internal refactor
+  mints a fake major release.
+- **Don't add `Co-Authored-By` trailers for LLM tools.**
+  Project preference — see _Commit / PR conventions_ above.
+- **Don't hand-edit `__version__` or `project.version`.**
+  `python-semantic-release` owns both; manual edits will be
+  overwritten on the next release and may confuse the version
+  bumper if they don't match.
+- **Don't commit the repo-root scratch files** (`out`,
+  `fix_ptr_recursion.py`, `no_recurse_default_pr.md`,
+  `test_recursion_flag.py`, `profile_discovery.py`,
+  `demo.py`) as part of an unrelated change. They're
+  in-progress investigation artefacts living outside the
+  package and outside the test suite — leave them where they
+  are unless you're explicitly working on the PTR-recursion
+  effort.
+- **Don't expand the install footprint casually.** This
+  library is on the import path of every Home Assistant
+  install; new runtime dependencies need to justify their
+  weight on import time and wheel size.


### PR DESCRIPTION
### Description of change

Adds a structured orientation file (`CLAUDE.md`) for LLM
contributors and a `pr-workflow` skill under
`.claude/skills/pr-workflow/SKILL.md` walking through filling
out PRs for this repo. Modeled after
[Bluetooth-Devices/dbus-fast#646](https://github.com/Bluetooth-Devices/dbus-fast/pull/646),
adapted to this repo's actual layout, toolchain, and conventions.

`CLAUDE.md` covers:

- **What this project is** — async ARP + DNS-PTR host discovery;
  the `DiscoverHosts` public surface; load-bearing use by Home
  Assistant's `dhcp` integration; cross-platform (Linux / macOS /
  Windows) constraints; sensitivity to upstream resolver
  behaviour (Quad9 / 1.1.1.1 rate limits).
- **Code style** — terse single-line docstrings, comment
  discipline (no rationale or issue refs in code), ruff config
  (line length 88, `target-version = "py310"`), the
  `aiodiscover/util.py` shim pattern for 3.11+ stdlib features,
  ruff-isort with `known-first-party = ["aiodiscover", "tests"]`,
  mypy in strict mode.
- **Commit / PR conventions** — Conventional Commits enforced by
  `commitlint` (per-commit) only — there is no separate
  `pr-title.yml` workflow on this repo, but the PR title still
  becomes the squash-merge subject and must parse cleanly.
  Accepted types, lowercase-subject rule, no header / body /
  footer length limits per `commitlint.config.mjs`. No
  `Co-Authored-By` trailers for LLM authorship.
- **Releases** — `python-semantic-release` reads the commit log
  and bumps `pyproject.toml:project.version` plus
  `aiodiscover/__init__.py:__version__`; `chore*` and `ci*` are
  excluded from the changelog. Don't hand-edit either version.
- **Running tests** — pure-Python, mocked end-to-end (no network,
  no system services); 3.10–3.14 × ubuntu / macOS / windows in
  CI.
- **Build conventions** — pure-Python Poetry build, no Cython, no
  C extensions; runtime deps pinned to floors only;
  `async_timeout` is conditional for `python < 3.11`.
- **Useful entry points** table covering `discovery.py`,
  `network.py`, `util.py`, the test modules, and the relevant
  config files.
- **Documentation drift** section flagging `CONTRIBUTING.md`,
  `tox.ini`, `Makefile`, and `README.md`'s "Four Commands" block
  as older than the current toolchain.
- **Things not to do** — 3.11+-only syntax, removing the platform
  guards in `network.py`, mis-typed Conventional Commits,
  hand-edits to `__version__`, committing the repo-root scratch
  files (`out`, `fix_ptr_recursion.py`, etc.) alongside unrelated
  changes, and `Co-Authored-By` for LLMs.

The `pr-workflow` skill summarises the parts that matter at
PR-creation time, calling out the differences from sibling repos:

- Branch from `origin/main`.
- Only one CI gate for Conventional Commits (`commitlint`), not
  two — but the PR title still ends up on `main` as the squash
  subject.
- Pick a type that matches release impact (`feat:` minor, `fix:`
  / `perf:` patch, `!` or `BREAKING CHANGE:` major; `chore:` /
  `docs:` / `test:` / `ci:` / `style:` / `build:` / `refactor:`
  don't bump; `chore*` and `ci*` are stripped from the changelog
  entirely).
- The PR template **does** exist on this repo (unlike
  `dbus-fast`) — fill in the description and the checklist rather
  than deleting them.
- Tests live under `aiodiscover/tests/`, not a top-level `tests/`
  directory.
- Use `--body-file` (not `--body "..."`) so backticks and
  Markdown survive shell quoting.
- Failure-mode hints: red `lint` job → unstaged auto-fix; red
  Windows / macOS cell → Linux-only path leak in `network.py`;
  red 3.10 cell → 3.11+ stdlib import that bypassed the `util.py`
  shim.

No runtime code changes; this PR only adds contributor-facing
documentation under `CLAUDE.md` and `.claude/`.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/bluetooth-devices/aiodiscover/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` — N/A
- [ ] There are new or updated unit tests validating the change — N/A (docs-only)
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".
