### PR TITLE
ci: authenticate release pushes via GitHub App installation token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,14 +84,10 @@ jobs:
       contents: write
 
     steps:
-      # Check out using the deploy key so PSR's later commit/tag push goes
-      # through SSH as the deploy-key actor — which is in the branch
-      # ruleset's bypass_actors list.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
-          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Create local branch name
         run: git switch -C ${{ github.head_ref || github.ref_name }}
@@ -103,13 +99,24 @@ jobs:
         with:
           no_operation_mode: true
 
+      # Mint a short-lived installation token for the release-bot GitHub
+      # App, which is in the main ruleset's bypass_actors list so PSR's
+      # version-bump commit/tag push isn't blocked by required checks.
+      - name: Generate release App token
+        if: github.ref_name == 'main'
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         id: release
         if: github.ref_name == 'main'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -119,4 +126,4 @@ jobs:
         uses: python-semantic-release/upload-to-gh-release@main
         if: steps.release.outputs.released == 'true'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Replace the SSH-deploy-key approach (#195) with a GitHub App installation token so PSR's auto-generated version-bump commit/tag can actually be pushed to `main` despite the `12 of 12 required status checks` ruleset.

### Why the deploy key didn't work

`python-semantic-release` doesn't push to the configured `origin` remote — its `gitproject.py:git_push_branch` calls `hvcs_client.remote_url(use_token=True)`, which constructs `https://x-access-token:TOKEN@github.com/owner/repo.git` from scratch. The SSH `origin` set up by `actions/checkout(ssh-key:)` was never consulted, so the push landed as `github-actions[bot]` (not in `bypass_actors`) and was rejected by branch protection — see the [latest failed run](https://github.com/Bluetooth-Devices/aiodiscover/actions/runs/25952861014/job/76293996917).

### What this PR changes

- Drop the `ssh-key:` input on the release-job checkout.
- Mint a short-lived installation token via `actions/create-github-app-token@v2` on the main path.
- Hand that token to both PSR and `upload-to-gh-release` via the existing `github_token` input. PSR's auth flow is unchanged; it just authenticates as the App, which is in `bypass_actors`.

## ⚠️ Prerequisites — set up before merging

This PR will fail on `main` until the following is in place. **Don't merge until done**, otherwise the next release attempt blocks the same way.

1. **Create a GitHub App** (org level recommended: `Bluetooth-Devices` org → Settings → Developer settings → GitHub Apps → New GitHub App).
   - Name: e.g. `aiodiscover-release-bot`
   - Homepage URL: any (e.g. the repo URL)
   - Webhook: disable
   - Repository permissions: **Contents: Read and write**, **Metadata: Read-only** (auto-included)
   - Where can this GitHub App be installed: *Only on this account*
2. **Generate a private key** for the App and download the `.pem` file.
3. **Install the App** on the `aiodiscover` repo (App page → Install App → choose `aiodiscover`).
4. **Add the App to the ruleset's `bypass_actors`**: repo Settings → Rules → Rulesets → the ruleset enforcing the 12 required checks on `main` → Bypass list → Add bypass → select the App. Set bypass mode to *Always*.
5. **Store the App credentials as environment secrets** on the `release` environment (Settings → Environments → release → Add secret):
   - `RELEASE_APP_ID` — the App's numeric ID (App page → About)
   - `RELEASE_APP_PRIVATE_KEY` — full contents of the downloaded `.pem` (including the `-----BEGIN/END-----` lines)
6. *(Optional cleanup)* Delete the now-unused `RELEASE_DEPLOY_KEY` environment secret and the corresponding deploy key in the repo's Deploy keys settings.

## Heads-up: this unblocks 3.0.0

Once this merges, PSR will classify the unreleased commits (including `feat!: drop Python 3.9 support`) and cut **3.0.0** as a major release. That's the intended outcome — flagging it so it's not a surprise.

## Test plan

- [ ] Complete the prerequisites above
- [ ] Verify CI on this PR is green (the `release` job only does a `--noop` dry-run on PR branches, so it can't validate the real push path here)
- [ ] After merge: confirm the release job pushes `3.0.0` commit + tag to `main`, uploads to PyPI, and creates the GitHub release