### PR TITLE
fix(network): accept pyroute2 darwin NEIGH_* attrs in neighbour reader

### DIFF
--- a/aiodiscover/network.py
+++ b/aiodiscover/network.py
@@ -45,6 +45,13 @@ LOOPBACK_TARGET_IP = "127.0.0.1"
 
 IGNORE_MACS = {"00:00:00:00:00:00", "ff:ff:ff:ff:ff:ff"}
 
+# pyroute2 reports neighbour attributes under different names depending on
+# the platform stub: Linux netlink uses NDA_*, the macOS stub added in
+# pyroute2 0.9.2 uses NEIGH_*. Accept both so the netlink path works on
+# either OS without falling all the way through to the arp -an reader.
+NEIGHBOUR_IP_KEYS = frozenset({"NDA_DST", "NEIGH_IP"})
+NEIGHBOUR_LLADDR_KEYS = frozenset({"NDA_LLADDR", "NEIGH_LLADDR"})
+
 RESOLV_CONF_PATH = "/etc/resolv.conf"
 
 
@@ -322,9 +329,9 @@ class SystemNetworkData:
             ip = None
             mac = None
             for key, value in neighbour["attrs"]:
-                if key == "NDA_DST":
+                if key in NEIGHBOUR_IP_KEYS:
                     ip = value
-                elif key == "NDA_LLADDR":
+                elif key in NEIGHBOUR_LLADDR_KEYS:
                     mac = value
             if ip and mac:
                 _fill_neighbor(neighbours, ip, mac)

--- a/aiodiscover/tests/test_network.py
+++ b/aiodiscover/tests/test_network.py
@@ -320,6 +320,45 @@ def test_async_populate_arp_swallows_send_errors() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_get_neighbours_ip_route_parses_linux_keys() -> None:
+    """Linux netlink NDA_DST / NDA_LLADDR attrs feed the neighbour map."""
+    ip_route = MagicMock()
+    ip_route.get_neighbours = MagicMock(
+        return_value=[
+            {
+                "attrs": [
+                    ("NDA_DST", "192.168.1.5"),
+                    ("NDA_LLADDR", "aa:bb:cc:dd:ee:ff"),
+                ],
+            },
+        ],
+    )
+    net_data = SystemNetworkData(ip_route)
+    result = await net_data._async_get_neighbours_ip_route()
+    assert result == {"192.168.1.5": "aa:bb:cc:dd:ee:ff"}
+
+
+@pytest.mark.asyncio
+async def test_async_get_neighbours_ip_route_parses_darwin_keys() -> None:
+    """pyroute2's macOS stub uses NEIGH_IP / NEIGH_LLADDR; both names parse."""
+    ip_route = MagicMock()
+    ip_route.get_neighbours = MagicMock(
+        return_value=[
+            {
+                "attrs": [
+                    ("NEIGH_IP", "192.168.1.6"),
+                    ("NEIGH_LLADDR", "11:22:33:44:55:66"),
+                    ("NEIGH_IFNAME", "en0"),
+                ],
+            },
+        ],
+    )
+    net_data = SystemNetworkData(ip_route)
+    result = await net_data._async_get_neighbours_ip_route()
+    assert result == {"192.168.1.6": "11:22:33:44:55:66"}
+
+
+@pytest.mark.asyncio
 async def test_async_get_neighbours_arp_parses_output() -> None:
     """The `arp -a -n` parser pulls ip + mac from each line."""
     arp_output = (


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/bluetooth-devices/aiodiscover/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

pyroute2 0.9.2 added a darwin `IPRoute` stub; on macOS that stub reports neighbours under `NEIGH_IP` / `NEIGH_LLADDR` attribute names rather than the Linux netlink `NDA_DST` / `NDA_LLADDR` pair the reader was matching on, so every neighbour was silently dropped and `async_discover()` returned an empty list on macOS once pyroute2 0.9.2 or newer was installed. This widens the match to both attribute name sets via top-level frozensets, so the netlink path keeps working on macOS; Linux behaviour is unchanged. Verified locally on macOS: discovery now returns the expected populated host list.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add \"N/A\" to the end.
-->

- [x] Code is up-to-date with the \`main\` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/bluetooth-devices/aiodiscover/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as \`Fixes #0000\` N/A
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as \"fix(api): prevent racing of requests\" (PRs are squash-merged, so the title becomes the commit on \`main\`).

> - If pre-commit.ci is failing, try \`pre-commit run -a\` for further information.
> - If CI / test is failing, try \`poetry run pytest\` for further information.

<!--
  🎉 Thank you for contributing!
-->