### PR TITLE
test: add blockbuster to detect blocking calls in asyncio tests

### DIFF
--- a/aiodiscover/tests/conftest.py
+++ b/aiodiscover/tests/conftest.py
@@ -1,11 +1,28 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 
+import pytest
 import pytest_asyncio
 
 from aiodiscover import discovery
+
+try:
+    from blockbuster import BlockBuster, blockbuster_ctx
+except ImportError:
+    BlockBuster = None  # type: ignore[assignment,misc]
+    blockbuster_ctx = None  # type: ignore[assignment]
+
+
+@pytest.fixture(autouse=True)
+def blockbuster() -> Iterator[BlockBuster | None]:
+    """Fail any test that performs a blocking call inside the asyncio loop."""
+    if blockbuster_ctx is None:
+        yield None
+        return
+    with blockbuster_ctx() as bb:
+        yield bb
 
 
 @pytest_asyncio.fixture

--- a/poetry.lock
+++ b/poetry.lock
@@ -138,6 +138,21 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
+name = "blockbuster"
+version = "1.5.26"
+description = "Utility to detect blocking calls in the async event loop"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "blockbuster-1.5.26-py3-none-any.whl", hash = "sha256:f8e53fb2dd4b6c6ec2f04907ddbd063ca7cd1ef587d24448ef4e50e81e3a79bb"},
+    {file = "blockbuster-1.5.26.tar.gz", hash = "sha256:cc3ce8c70fa852a97ee3411155f31e4ad2665cd1c6c7d2f8bb1851dab61dc629"},
+]
+
+[package.dependencies]
+forbiddenfruit = {version = ">=0.1.4", markers = "implementation_name == \"cpython\""}
+
+[[package]]
 name = "cached-ipaddress"
 version = "1.0.1"
 description = "Cache construction of ipaddress objects"
@@ -597,6 +612,18 @@ files = [
 
 [package.extras]
 test = ["pytest (>=6)"]
+
+[[package]]
+name = "forbiddenfruit"
+version = "0.1.4"
+description = "Patch python built-in objects"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+markers = "implementation_name == \"cpython\""
+files = [
+    {file = "forbiddenfruit-0.1.4.tar.gz", hash = "sha256:e3f7e66561a29ae129aac139a85d610dbf3dd896128187ed5454b6421f624253"},
+]
 
 [[package]]
 name = "furo"
@@ -2103,4 +2130,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "ef967534650bf64da636b244159310d3a15bf6da4c924da540635d3f94d57858"
+content-hash = "beef64c1407434ee76fc6852f350e8b4deadc494a51342b6680fd6a0e813dcbf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ pytest-asyncio = ">=0.23.7,<1.2.0"
 pytest-sugar = "^1.1.1"
 pytest-timeout = "^2.3.1"
 mypy = "^1.19.1"
+blockbuster = ">=1.5.5,<2.0.0"
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
### Description of change

Adds blockbuster as a dev dependency, wired in as an autouse fixture in the test conftest; it patches sync IO calls so any blocking call made inside an asyncio test fails the test instead of silently slowing the loop.

The full suite passes cleanly under blockbuster, so no xfail list is needed; the import is guarded behind try or except ImportError so the s390x QEMU leg (where blockbuster is harder to install) keeps working.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/bluetooth-devices/aiodiscover/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests" (PRs are squash-merged, so the title becomes the commit on `main`).