### PR TITLE
ci: install astral managed Python so prerelease setup is cached

### DIFF
--- a/.github/actions/setup-uv-python/action.yml
+++ b/.github/actions/setup-uv-python/action.yml
@@ -1,0 +1,48 @@
+name: Set up uv and managed Python
+description: >-
+  Pins uv (avoids the raw.githubusercontent.com manifest fetch on cache miss)
+  and proactively installs the requested Python so cached venvs resolve their
+  interpreter symlinks in jobs that only restore the venv. setup-uv alone
+  only sets UV_PYTHON, it does not actually fetch the interpreter until uv
+  first uses it, so jobs that just activate a cached venv blow up with
+  broken symlinks on cache hit.
+
+inputs:
+  python-version:
+    description: The Python version uv should install and use.
+    required: true
+  uv-version:
+    description: The uv version setup-uv should install.
+    required: true
+
+outputs:
+  python-version:
+    description: The Python version uv reports as installed.
+    value: ${{ steps.uv.outputs.python-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up uv
+      id: uv
+      uses: astral-sh/setup-uv@v8.1.0
+      with:
+        version: ${{ inputs.uv-version }}
+        python-version: ${{ inputs.python-version }}
+        # Persist astral's managed Python across jobs so 'uv venv' / poetry
+        # env use below is fast on the second job onwards.
+        cache-python: true
+        # Jobs that only configure the toolchain (no deps to cache) would
+        # otherwise abort with "Nothing to cache" on the post step.
+        ignore-nothing-to-cache: true
+    - name: Install Python interpreter
+      shell: bash
+      env:
+        PYTHON_VERSION: ${{ inputs.python-version }}
+      # 'uv python install' on Windows blows up with a reparse-point tag
+      # mismatch (os error 4394) when cache-python: true already restored
+      # the install dir, so only install when find says we have nothing yet.
+      run: |
+        if ! uv python find "${PYTHON_VERSION}" >/dev/null 2>&1; then
+          uv python install "${PYTHON_VERSION}"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
   POETRY_VIRTUALENVS_IN_PROJECT: "true"
   UV_PYTHON_PREFERENCE: only-managed
+  UV_VERSION: "0.11.16"
 
 jobs:
   lint:
@@ -62,28 +63,27 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+      - name: Set up uv and Python ${{ matrix.python-version }}
+        id: python
+        uses: ./.github/actions/setup-uv-python
         with:
-          enable-cache: true
+          uv-version: ${{ env.UV_VERSION }}
+          python-version: ${{ matrix.python-version }}
       - name: Install poetry
         run: uv tool install poetry
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        id: setup-python
-        with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-          cache: poetry
+        shell: bash
       - name: Cache poetry venv
         id: cache-venv
         uses: actions/cache@v5
         with:
           path: .venv
-          key: venv-v1-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml') }}
+          key: venv-v2-${{ runner.os }}-py${{ steps.python.outputs.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
+          poetry env use "$(uv python find "${PYTHON_VERSION}")"
           poetry install --only=main,dev
         shell: bash
       - name: Test with Pytest


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/bluetooth-devices/aiodiscover/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Move the test matrix off actions/setup-python and onto astral managed Python via a small composite action. setup-python downloads the manifest on every cache miss, which is especially slow on Windows for prerelease 3.14; uv keeps the interpreter cached across jobs, so subsequent runs skip that fetch entirely.

The composite action pins uv, asks setup-uv to fetch and cache the interpreter, then runs uv python install so cached venvs whose symlinks point at the managed python still resolve on restore. Poetry is pointed at that interpreter with poetry env use on cache miss. Cache key bumped v1 to v2 to drop stale entries that pointed at the old setup-python interpreter.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/bluetooth-devices/aiodiscover/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests" (PRs are squash-merged, so the title becomes the commit on `main`).

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->