### PR TITLE
fix(network): read resolv.conf off the event loop

### DIFF
--- a/aiodiscover/network.py
+++ b/aiodiscover/network.py
@@ -264,8 +264,11 @@ class SystemNetworkData:
         # resolv.conf is absent on Windows (the FileNotFoundError below is
         # swallowed there) and so later code can iterate unconditionally.
         self.nameservers = []
+        loop = asyncio.get_running_loop()
         try:
-            signature, resolvers = load_resolv_conf_with_signature()
+            signature, resolvers = await loop.run_in_executor(
+                None, load_resolv_conf_with_signature
+            )
         except FileNotFoundError:
             if sys.platform != "win32":
                 raise

--- a/aiodiscover/tests/test_network.py
+++ b/aiodiscover/tests/test_network.py
@@ -160,6 +160,34 @@ async def test_setup_router_ip_fallback_uses_first_network_host(
 
 
 @pytest.mark.asyncio
+async def test_setup_reads_resolv_conf_off_the_event_loop() -> None:
+    """async_setup performs the blocking resolv.conf read in an executor."""
+    ran_without_running_loop = False
+
+    def fake_load() -> tuple[ResolvConfSignature, list[IPv4Address]]:
+        nonlocal ran_without_running_loop
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            ran_without_running_loop = True
+        return ResolvConfSignature(0, 0), [IPv4Address("192.168.1.53")]
+
+    adapter = MagicMock()
+    adapter.ips = [MagicMock(ip="192.168.1.10", network_prefix=24)]
+    net_data = SystemNetworkData(None, local_ip="192.168.1.10")
+    with (
+        patch(
+            "aiodiscover.network.load_resolv_conf_with_signature",
+            side_effect=fake_load,
+        ),
+        patch("aiodiscover.network.ifaddr.get_adapters", return_value=[adapter]),
+    ):
+        await net_data.async_setup()
+    assert ran_without_running_loop
+    assert net_data.nameservers == [IPv4Address("192.168.1.53")]
+
+
+@pytest.mark.asyncio
 async def test_setup_propagates_missing_resolv_conf_on_non_windows() -> None:
     """On Linux/macOS, a missing resolv.conf still bubbles up."""
     net_data = SystemNetworkData(None, local_ip="192.168.1.10")


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/bluetooth-devices/aiodiscover/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Since 3.3.0, Home Assistant reports a blocking `open('/etc/resolv.conf')` in the event loop on every startup. The AsyncIPRoute migration in #263 made `async_setup` a coroutine and started reading resolv.conf inline on the loop; before that, the whole setup ran inside `run_in_executor`, so the read never touched the loop. This moves the blocking read back into an executor.

The existing blockbuster fixture did not catch the regression because `load_resolv_conf_with_signature` iterates the file with `tuple(file)`, which uses `readline`, and blockbuster only patches `read`. The new test pins the read to an executor directly instead of relying on blockbuster.

Reported in home-assistant/core#173345.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/bluetooth-devices/aiodiscover/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` N/A (issue is in home-assistant/core)
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The pull request title follows the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests" (PRs are squash-merged, so the title becomes the commit on `main`).

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
